### PR TITLE
fix bugs after python3.6 in alarm.py

### DIFF
--- a/alarm.py
+++ b/alarm.py
@@ -104,7 +104,7 @@ def get_netwrok_metric(trace_file, pod_name):
 
     try:
         pod_spans = pod_reader.loc[[pod_name], [
-            'SpanID', 'ParentID', 'PodName', 'EndTimeUnixNano']]
+            'SpanID', 'ParentID', 'EndTimeUnixNano']]
     except:
         service = pod_name.rsplit('-', 1)[0]
         service = service.rsplit('-', 1)[0]


### PR DESCRIPTION
After python 3.6, the index column will not be presented in the pandas.Dataframe. This can lead to the following code encountering an error:

```python
pod_spans = pod_reader.loc[[pod_name], [
            'SpanID', 'ParentID', 'EndTimeUnixNano']]
```